### PR TITLE
Fix building of kdbg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS
     IconThemes
     XmlGui
     WindowSystem
+    KDELibs4Support
 )
 
 include(KDEInstallDirs)

--- a/kdbg/CMakeLists.txt
+++ b/kdbg/CMakeLists.txt
@@ -94,6 +94,7 @@ target_link_libraries(kdbg
     KF5::IconThemes
     KF5::XmlGui
     KF5::WindowSystem
+    KF5::KDELibs4Support
     ${LIB_UTIL}
 )
 

--- a/kdbg/brkpt.cpp
+++ b/kdbg/brkpt.cpp
@@ -6,7 +6,6 @@
 
 #include <klocale.h>			/* i18n */
 #include <kiconloader.h>
-#include <ksimpleconfig.h>
 #include <QDialog>
 #include <QFileInfo>
 #include <QPainter>


### PR DESCRIPTION
Add KDELibs4Support in CMakeLists.txt (i18n via klocale.h need this).
Remove unnecessary include from brkpt.cpp (this include removed in the recent versions of kdeframeworks).