### PR TITLE
.gitignore add support for clangd, vscode, kdesrc-build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ Makefile
 kdbg/kdbg_autogen/
 prefix.sh
 install_manifest.txt
+CMakeLists.txt.user*
+/compile_commands.json


### PR DESCRIPTION
I build kdbg using kdesrc-build.
The .gitinore file that more than 30 KDE git repositories use is
https://invent.kde.org/frameworks/ki18n/-/blob/master/.gitignore
I added some lines form https://invent.kde.org/frameworks/ki18n/-/blob/master/.gitignore
to .gitignore.
Because these two files: "compile_commands.json" and "CMakeLists.txt.user"
exist in the git work directory after building kdbg using kdesrc-build.
See https://invent.kde.org/nmariusp/kdesrc-build-extra