### PR TITLE
xsldbgdriver ctor cannot return null

### DIFF
--- a/kdbg/xsldbgdriver.cpp
+++ b/kdbg/xsldbgdriver.cpp
@@ -680,9 +680,7 @@ parseVar(const char *&s)
         return 0;
       }
       variable = new ExprValue(name, kind);
-      if (variable != 0L) {
-	  variable->m_varKind = VarTree::VKsimple;
-      }
+      variable->m_varKind = VarTree::VKsimple;
     }else{
       p++;
       // skip whitespace
@@ -693,14 +691,12 @@ parseVar(const char *&s)
         return 0;
       }
       variable = new ExprValue(name, kind);
-      if (variable != 0L) {
-	  variable->m_varKind = VarTree::VKsimple;
-      }
+      variable->m_varKind = VarTree::VKsimple;
       if (*p == '\n')
-	p++;
+        p++;
       if (!parseValue(p, variable)) {
-	delete variable;
-	return 0;
+        delete variable;
+        return 0;
       }
     }
 


### PR DESCRIPTION
Fix PVS-Studio issue "xsldbgdriver.cpp:683: warning: V668
There is no sense in testing the 'variable' pointer against null,
as the memory was allocated using the 'new' operator.
The exception will be generated in the case of memory allocation error.".