### PR TITLE
kdbg/main.cpp: Stop adding --version, --help, --help-all twice (fixes #27)

### DIFF
--- a/kdbg/main.cpp
+++ b/kdbg/main.cpp
@@ -54,9 +54,6 @@ int main(int argc, char** argv)
 
     QCommandLineParser parser;
     aboutData.setupCommandLine(&parser);
-    parser.setApplicationDescription(aboutData.shortDescription());
-    parser.addHelpOption();
-    parser.addVersionOption();
 
     auto opt = [&](const char* opt, QString desc, const char* arg) {
 	parser.addOption(QCommandLineOption(QStringList() << QLatin1String(opt), desc, QLatin1String(arg)));


### PR DESCRIPTION
Fixes #27

Symptom was:

```console
# kdbg --version
QCommandLineParser: already having an option named "h"
QCommandLineParser: already having an option named "help-all"
QCommandLineParser: already having an option named "v"
kdbg 3.0.1
```

`KAboutData::setupCommandLine` is already adding these for us, so no need to add them again, ourselves.

Related docs:
https://api.kde.org/frameworks/kcoreaddons/html/classKAboutData.html#afaf16b9be9deacfe10669219c50f2b43