### PR TITLE
Replace http:// by https:// where appropriate + fix dead link on regex syntax

### DIFF
--- a/ChangeLog-pre-2.2.0
+++ b/ChangeLog-pre-2.2.0
@@ -1,6 +1,6 @@
 Later versions
 
-	Please use the gitweb log at http://repo.or.cz/w/kdbg.git to browse
+	Please use the gitweb log at https://repo.or.cz/w/kdbg.git to browse
 	the changes.
 
 Version 2.0.4
@@ -11,7 +11,7 @@ Version 2.0.4
 
 	Fixed that the debugger window really comes to the foreground and
 	receives the focus when the debuggee stops at a breakpoint, when this
-	option is on (http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=171845).
+	option is on (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=171845).
 
 	Added a filter edit box to the Attach to Process dialog to improve
 	usability.

--- a/README
+++ b/README
@@ -17,6 +17,6 @@ that the development packages are installed.
 
 The homepage is at
 
-	http://www.kdbg.org/
+	https://www.kdbg.org/
 
 Johannes Sixt <j6t@kdbg.org>

--- a/kdbg.spec
+++ b/kdbg.spec
@@ -17,7 +17,7 @@ Distribution: RedHat 7.0
 Vendor: Johannes Sixt <j6t@kdbg.org>
 Packager: Ullrich von Bassewitz <uz@musoftware.de>
 Source: %{name}-%{version}.tar.gz
-URL: http://www.kdbg.org/
+URL: https://www.kdbg.org/
 Requires: kdelibs >= 2.0
 BuildRoot: /tmp/build-%{name}-%{version}
 

--- a/kdbg/doc/de/index.html
+++ b/kdbg/doc/de/index.html
@@ -169,6 +169,6 @@ verändern können.</p>
 <a NAME="Author"></a>Autor</h2>
 <p>KDbg wurde von <a href="mailto:j6t@kdbg.org">Johannes Sixt</a>
 mit vielen weiteren Helfern geschrieben.
-<br>Die KDbg-Homepage befindet sich unter <a href="http://www.kdbg.org/">http://www.kdbg.org/</a>.</p>
+<br>Die KDbg-Homepage befindet sich unter <a href="https://www.kdbg.org/">https://www.kdbg.org/</a>.</p>
 </body>
 </html>

--- a/kdbg/doc/en/index.html
+++ b/kdbg/doc/en/index.html
@@ -180,6 +180,6 @@ with contributions from many people, among others (in no particular order):</p>
 <li>Daniel Thor Kristjansson</li>
 <li>Matthew Allen</li>
 </ul>
-<p>KDbg homepage is at <a href="http://www.kdbg.org/">http://www.kdbg.org/</a>.</p>
+<p>KDbg homepage is at <a href="https://www.kdbg.org/">https://www.kdbg.org/</a>.</p>
 </body>
 </html>

--- a/kdbg/doc/en/types.html
+++ b/kdbg/doc/en/types.html
@@ -56,7 +56,7 @@ Sometimes the order in which the names are listed is important
 <tt>ShlibRE</tt>. KDbg uses this entry to determine if the type table applies
 to the program being debugged. For this purpose KDbg determines the shared
 libraries to which the program is linked. If any of the libraries matches
-this entry, the type table applies. The entry is a <a href="https://doc.trolltech.com/4.0/qregexp.html#introduction">Qt regular
+this entry, the type table applies. The entry is a <a href="https://doc.qt.io/qt-5/qregexp.html#introduction">Qt regular
 expression</a>.
 Note that back-slashes must be doubled because the back-slash is an escape
 character in the configuration file syntax.</li>

--- a/kdbg/doc/en/types.html
+++ b/kdbg/doc/en/types.html
@@ -56,7 +56,7 @@ Sometimes the order in which the names are listed is important
 <tt>ShlibRE</tt>. KDbg uses this entry to determine if the type table applies
 to the program being debugged. For this purpose KDbg determines the shared
 libraries to which the program is linked. If any of the libraries matches
-this entry, the type table applies. The entry is a <a href="http://doc.trolltech.com/4.0/qregexp.html#introduction">Qt regular
+this entry, the type table applies. The entry is a <a href="https://doc.trolltech.com/4.0/qregexp.html#introduction">Qt regular
 expression</a>.
 Note that back-slashes must be doubled because the back-slash is an escape
 character in the configuration file syntax.</li>

--- a/kdbg/doc/en/xslt.html
+++ b/kdbg/doc/en/xslt.html
@@ -9,7 +9,7 @@
 <p><a href="index.html">Contents</a></p>
 <h1>Debugging XSLT scripts</h1>
 <p>KDbg allows to debug XSLT (XML stylesheet translation) scripts using
-<a href="http://xsldbg.sourceforge.net/">xsldbg</a>, which must be available
+<a href="https://xsldbg.sourceforge.net/">xsldbg</a>, which must be available
 on your system.</p>
 <h2>Specifying the script and an XML file to transform</h2>
 <p>XSLT mode is automatically entered if a &quot;program&quot; is loaded

--- a/kdbg/doc/ru/index.html
+++ b/kdbg/doc/ru/index.html
@@ -172,6 +172,6 @@ gdb 4.16 имеет проблемы с обработкой классов С++ с виртуальным базовым классом.
 KDbg разработан <a href="mailto:j6t@kdbg.org">Johannes Sixt</a>
 с помощью многих остальных.
 <br>Домашняя страница KDbg расположена по адресу  
-<a href="http://www.kdbg.org/">http://www.kdbg.org/</a>.
+<a href="https://www.kdbg.org/">https://www.kdbg.org/</a>.
 </body>
 </html>

--- a/kdbg/main.cpp
+++ b/kdbg/main.cpp
@@ -30,7 +30,7 @@ int main(int argc, char** argv)
 			 KAboutLicense::GPL_V2,
 			 i18n("(c) 1998-2020 Johannes Sixt"),
 			 {},	/* any text */
-			 "http://www.kdbg.org/",
+			 "https://www.kdbg.org/",
 			 "j6t@kdbg.org");
     aboutData.addAuthor(i18n("Johannes Sixt"), QString(), "j6t@kdbg.org");
     aboutData.addCredit(i18n("Keith Isdale"),


### PR DESCRIPTION
Likely the last pull request and/or issue here today…

Note that the places where I did *not* replace `http://` by `https://` should all fall into one of these two buckets:
- XML namespace URIs
- XML doctype URIs