### PR TITLE
Bump to GCC 10, GCC 14 (and Clang 18) to fix CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,10 +27,10 @@ jobs:
             clang_major_version: null
             clang_repo_suffix: null
             runs-on: ubuntu-24.04
-          - cc: clang-17
-            cxx: clang++-17
-            clang_major_version: 17
-            clang_repo_suffix: -17
+          - cc: clang-18
+            cxx: clang++-18
+            clang_major_version: 18
+            clang_repo_suffix: -18
             runs-on: ubuntu-22.04
     steps:
       - name: Add Clang/LLVM repositories

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,16 +17,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cc: gcc-9
-            cxx: g++-9
+          - cc: gcc-10
+            cxx: g++-10
             clang_major_version: null
             clang_repo_suffix: null
             runs-on: ubuntu-22.04
-          - cc: gcc-13
-            cxx: g++-13
+          - cc: gcc-14
+            cxx: g++-14
             clang_major_version: null
             clang_repo_suffix: null
-            runs-on: ubuntu-22.04
+            runs-on: ubuntu-24.04
           - cc: clang-17
             cxx: clang++-17
             clang_major_version: 17


### PR DESCRIPTION
.. because `ubuntu-22.04` suddenly dropped GCC 13.

Related:
- https://github.com/actions/runner-images/issues/9866
- https://github.com/actions/runner-images/issues/9679

CC @j6t 