### PR TITLE
[needs more work w/ KF5 if desired] Allow to build with Qt6/KF6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 3.16)
 project(KDbg)
 set(QT_MIN_VERSION "5.15.0")
-set(KF5_MIN_VERSION "5.84.0")
+set(KF_MIN_VERSION "5.89.0")
 
 set(KDBG_VERSION 3.1.0)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/kdbg/version.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/kdbg/version.h)
 
-find_package(ECM REQUIRED NO_MODULE)
+find_package(ECM ${KF_MIN_VERSION} REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH})
 
 include(KDEInstallDirs)
@@ -14,11 +14,14 @@ include(KDECMakeSettings)
 include(KDECompilerSettings NO_POLICY_SCOPE)
 include(FeatureSummary)
 
-find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
+find_package(Qt${QT_MAJOR_VERSION} ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     Core Widgets
 )
+if(QT_MAJOR_VERSION EQUAL 6)
+    find_package(Qt${QT_MAJOR_VERSION}Core5Compat CONFIG REQUIRED)
+endif()
 
-find_package(KF5 ${KF5_MIN_VERSION} REQUIRED COMPONENTS
+find_package(KF${QT_MAJOR_VERSION} ${KF_MIN_VERSION} REQUIRED COMPONENTS
     I18n
     Config
     CoreAddons

--- a/kdbg/CMakeLists.txt
+++ b/kdbg/CMakeLists.txt
@@ -89,16 +89,21 @@ IF (HAVE_LIB_UTIL)
 ENDIF (HAVE_LIB_UTIL)
 
 target_link_libraries(kdbg
-    KF5::I18n
-    KF5::ConfigCore
-    KF5::CoreAddons
-    KF5::IconThemes
-    KF5::XmlGui
-    KF5::WindowSystem
+    KF${QT_MAJOR_VERSION}::I18n
+    KF${QT_MAJOR_VERSION}::ConfigCore
+    KF${QT_MAJOR_VERSION}::CoreAddons
+    KF${QT_MAJOR_VERSION}::IconThemes
+    KF${QT_MAJOR_VERSION}::WindowSystem
+    KF${QT_MAJOR_VERSION}::XmlGui
     ${LIB_UTIL}
 )
+if(QT_MAJOR_VERSION EQUAL 6)
+    target_link_libraries(kdbg
+        Qt::Core5Compat
+    )
+endif()
 
 install(TARGETS kdbg ${KDE_INSTALL_TARGETS_DEFAULT_ARGS})
 install(FILES kdbg.desktop DESTINATION ${KDE_INSTALL_APPDIR})
 install(FILES kdbgrc DESTINATION ${KDE_INSTALL_CONFDIR})
-install(FILES kdbgui.rc DESTINATION ${KDE_INSTALL_KXMLGUI5DIR}/kdbg)
+install(FILES kdbgui.rc DESTINATION ${KDE_INSTALL_KXMLGUIDIR}/kdbg)


### PR DESCRIPTION
As mentioned in https://github.com/j6t/kdbg/pull/49, this would need more work to actually build with Qt5/KF5 due to raising minimum ECM version to KF_MIN_VERSION.

`QT_MAJOR_VERSION` is set by ECM facilities, unless overridden by user when calling cmake.

I am personally not interested in spending time on that, but this is how such CMake would look like, up to KDE standards.