### PR TITLE
`memwindow.cpp`: Dissolve use of signal that was removed in Qt 6 (fixes #52)

### DIFF
--- a/kdbg/memwindow.cpp
+++ b/kdbg/memwindow.cpp
@@ -59,7 +59,7 @@ MemoryWindow::MemoryWindow(QWidget* parent) :
     m_layout.addWidget(&m_memory, 10);
     m_layout.activate();
 
-    connect(&m_expression, SIGNAL(activated(const QString&)),
+    connect(&m_expression, SIGNAL(textActivated(const QString&)),
 	    this, SLOT(slotNewExpression(const QString&)));
     connect(m_expression.lineEdit(), SIGNAL(returnPressed()),
 	    this, SLOT(slotNewExpression()));


### PR DESCRIPTION
Fixes #52

Related docs:
https://doc.qt.io/archives/qt-5.15/qcombobox-obsolete.html#activated-1