### PR TITLE
Fix CI / Migrate from defunct Ubuntu 24.10/oracular to Ubuntu 25.04/plucky

### DIFF
--- a/.github/workflows/debian_package.yml
+++ b/.github/workflows/debian_package.yml
@@ -37,7 +37,7 @@ jobs:
               qtbase5-dev
             )
           else
-            sudo sed 's,noble,oracular,g' -i /etc/apt/sources.list.d/ubuntu.sources  # Ubuntu 24.10
+            sudo sed 's,noble,plucky,g' -i /etc/apt/sources.list.d/ubuntu.sources  # Ubuntu 25.04
             extra_packages=(
               libkf6config-dev
               libkf6i18n-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -65,7 +65,7 @@ jobs:
               qtbase5-dev
             )
           else
-            sudo sed 's,noble,oracular,g' -i /etc/apt/sources.list.d/ubuntu.sources  # Ubuntu 24.10
+            sudo sed 's,noble,plucky,g' -i /etc/apt/sources.list.d/ubuntu.sources  # Ubuntu 25.04
             extra_packages=(
               libkf6config-dev
               libkf6i18n-dev


### PR DESCRIPTION
Related:
- https://archive.ubuntu.com/ubuntu/dists/ (where there is no sign of oracular any more)
- https://endoflife.date/ubuntu