### PR TITLE
Show the build dependencies in the README

### DIFF
--- a/README
+++ b/README
@@ -25,3 +25,6 @@ The homepage is at
 	https://www.kdbg.org/
 
 Johannes Sixt <j6t@kdbg.org>
+
+Install dependencies for Debian 6.12
+sudo apt install libkf6iconthemes-dev libkf6xmlgui-dev libkf6windowsystem-dev 

--- a/README
+++ b/README
@@ -26,5 +26,5 @@ The homepage is at
 
 Johannes Sixt <j6t@kdbg.org>
 
-Install dependencies for Debian 6.12
+Build dependencies for Debian 6.12
 sudo apt install libkf6iconthemes-dev libkf6xmlgui-dev libkf6windowsystem-dev 


### PR DESCRIPTION
I added a couple of lines in the README to show the build dependencies for a recent Debian system.