### PR TITLE
Preserve source window's scrollbar and cursor positions on file reload.

### DIFF
--- a/kdbg/sourcewnd.cpp
+++ b/kdbg/sourcewnd.cpp
@@ -7,6 +7,7 @@
 #include "debugger.h"
 #include "sourcewnd.h"
 #include "dbgdriver.h"
+#include <QScrollBar>
 #include <QTextStream>
 #include <QPainter>
 #include <QFile>
@@ -97,6 +98,11 @@ bool SourceWindow::loadFile()
 
 void SourceWindow::reloadFile()
 {
+    // save scrollbar and cursor positions
+    int x = horizontalScrollBar()->value();
+    int y = verticalScrollBar()->value();
+    int row = textCursor().blockNumber();
+
     QFile f(m_fileName);
     if (!f.open(QIODevice::ReadOnly)) {
 	// open failed; leave alone
@@ -131,6 +137,13 @@ void SourceWindow::reloadFile()
 	m_highlighter->rehighlight();
 
     restorePrevDisass();
+
+    // restore cursor and scrollbar positions
+    QTextCursor cursor(document()->findBlockByNumber(row));
+    setTextCursor(cursor);
+
+    horizontalScrollBar()->setValue(x);
+    verticalScrollBar()->setValue(y);
 }
 
 void SourceWindow::scrollTo(int lineNo, const DbgAddr& address)


### PR DESCRIPTION
This commit fixes an annoying issue where the source window jumps to the
beginning of the file on source code reload. This breaks a good debugging
workflow as one has to manually scroll to line number or use the find dialog
to find changes made. Preserveing the line cursor also helps as one
can immediatly use arrow keys to change cursor position, instead of using a
mouse to bring the cursor from the beginning of the file to the needed line.

This is accomplished by preserving the scrollbar and line cursor positions
in `SourceWindow::reloadFile` and restoring at the end once the file is
loaded again.